### PR TITLE
deps: bump asyncssh to 2.23.1 (GHSA-2wxc-x7rj-hg8f)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ftp = [
   "aioftp==0.27.2",
 ]
 sftp = [
-  "asyncssh==2.23.0",
+  "asyncssh==2.23.1",
 ]
 cassandra = [
   "cassandra-driver==3.29.3; sys_platform != 'win32' and python_version < '3.14'",

--- a/uv.lock
+++ b/uv.lock
@@ -257,15 +257,15 @@ wheels = [
 
 [[package]]
 name = "asyncssh"
-version = "2.23.0"
+version = "2.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/fd/c34fe7e30838b4b9cc91903da26a62c6d33b673c731b3d951fcd70ab1889/asyncssh-2.23.0.tar.gz", hash = "sha256:8c54760953c1f2cf282591bcba5c8c70efc48d645bbf26bd2307a9c66a0ed1a7", size = 542154, upload-time = "2026-05-09T03:15:01.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/95/212d3d394f2a6ccb3f95056d3b9a7ce13c2f58503cbd6a38d037ef48cb13/asyncssh-2.23.1.tar.gz", hash = "sha256:d9dc3bc0206f3e4b5d80d1c0e6a24af2b4ad4beb556884c41fb2ad1c7ca3f44f", size = 542883, upload-time = "2026-06-07T14:15:18.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/b5/b1a3979f4840d1271ca8e0978dbccfb18ad2d33b4ece85cf77122fb46e5f/asyncssh-2.23.0-py3-none-any.whl", hash = "sha256:14108bfdaae17457f0c1841e883ad934271bbfdd46458aa4c4d0973451940ad0", size = 375687, upload-time = "2026-05-09T03:15:00.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/94/9aa81bde40627af70388d634152e7c53e7533788e662b8093047501a1473/asyncssh-2.23.1-py3-none-any.whl", hash = "sha256:f68e55476d41253d785bcac9a90834ae5fdea0f417bd6d7182608bda248de88e", size = 376054, upload-time = "2026-06-07T14:15:17.375Z" },
 ]
 
 [[package]]
@@ -480,7 +480,7 @@ name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_version < '0'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
@@ -2333,7 +2333,7 @@ requires-dist = [
     { name = "aioftp", marker = "extra == 'ftp'", specifier = "==0.27.2" },
     { name = "aiomysql", marker = "extra == 'mysql'", specifier = "==0.3.2" },
     { name = "asyncpg", marker = "extra == 'postgresql'", specifier = "==0.31.0" },
-    { name = "asyncssh", marker = "extra == 'sftp'", specifier = "==2.23.0" },
+    { name = "asyncssh", marker = "extra == 'sftp'", specifier = "==2.23.1" },
     { name = "cassandra-driver", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'cassandra'", specifier = "==3.29.3" },
     { name = "charset-normalizer", specifier = "==3.5.1" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = "==1.5.1" },


### PR DESCRIPTION
Updates asyncssh to address GHSA-2wxc-x7rj-hg8f (CVE-2026-54591, SCP path traversal to arbitrary file write) and GHSA-qr67-gv47-xwwh (AuthorizedKeysFile %u directory escape).

Evidence:
- `pyproject.toml` pinned `asyncssh==2.23.0` in the sftp extra
- `pip-audit` reported GHSA-2wxc-x7rj-hg8f for asyncssh 2.23.0
- updated version: 2.23.1

Validation:
- `pip-audit` reports no known vulnerabilities for asyncssh 2.23.1
- `uv lock --check` passes
- `uv run --group dev pytest -o "anyio_mode=auto"` passes: 177 passed, 66 skipped

Scope: pyproject.toml and uv.lock only.
